### PR TITLE
Compile fix

### DIFF
--- a/jconfig.vc
+++ b/jconfig.vc
@@ -28,6 +28,13 @@ typedef unsigned char boolean;
 #endif
 #define HAVE_BOOLEAN		/* prevent jmorecfg.h from redefining it */
 
+/* Define "INT32" as int, not long, per Windows custom */
+#if !(defined(_BASETSD_H_) || defined(_BASETSD_H))   /* don't conflict if basetsd.h already read */
+typedef short INT16;
+typedef signed int INT32;
+#endif
+#define XMD_H                   /* prevent jmorecfg.h from redefining it */
+
 
 #ifdef JPEG_INTERNALS
 


### PR DESCRIPTION
I've been able to build this just fine before, unsure when or why this suddenly became an issue.

From the commit message:

> Fixed an issue whereby Windows applications that used libjpeg-turbo would
> fail to compile if the Windows system headers were included before jpeglib.h.
> This issue was caused by a conflict in the definition of the INT32 type.

https://github.com/libjpeg-turbo/libjpeg-turbo/commit/eed08614a61f0a7c23e4eae0b50efd8d11194c40